### PR TITLE
:sparkles: ログインとサインアップ用のボタン、ルーティング定義

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,8 @@ import { User } from './type';
 import { getCurrentUser } from './utils/auth';
 import { useRequestStatus } from './hooks/use_request_status';
 import { RequestStatusState } from './stores/request_status_reducer';
+import SignUp from '@/components/SignUp/SignUp';
+import SignIn from '@/components/SignIn/SignIn';
 
 type RequestContext = {
   requestState: RequestStatusState;
@@ -78,6 +80,8 @@ function App() {
               </div>
               <div className="main__contents">
                 <Routes>
+                  <Route path="/signup" element={<SignUp />} />
+                  <Route path="/signin" element={<SignIn />} />
                   <Route path="/" element={<Restaurants />} />
                   <Route path="/restaurants" element={<Restaurants />} />
                   <Route path="/restaurants/:restaurantsId/foods" element={<Foods />} />

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -5,7 +5,8 @@ import { useContext, useEffect } from 'react';
 import ApiClient from '@/utils/api-client';
 import { lineFoodsCount, REQUEST_STATE } from '@/config/constants';
 import { CartContext, RequestContext } from '@/App';
-import { Badge } from '../Badge/Badge';
+import { Badge } from '@/components/Badge/Badge';
+import { Button } from '@/components/Button/Button';
 
 type User = {
   name: string;
@@ -79,12 +80,16 @@ export const Header = ({ title, logoUrl, navigations, isDark = false, isFixed = 
         <div className={styles.o_header__right_contents}>
           <div className={styles.o_header__navigation_icon_wrapper}>
             <Link to="/orders">
-              <img src={CartIcon} alt="Cart" className={styles.o_header__navigation_icon} />
-              {requestState.status === REQUEST_STATE.OK && cartCount !== 0 && (
-                <Badge type="success" label={cartCount.toString()} />
-              )}
+              <div className={styles.o_header__orders_link}>
+                <img src={CartIcon} alt="Cart" className={styles.o_header__navigation_icon} />
+                {requestState.status === REQUEST_STATE.OK && cartCount !== 0 && (
+                  <Badge type="success" label={cartCount.toString()} />
+                )}
+              </div>
             </Link>
           </div>
+          <Button label="ログイン" size="small" type="neutral" />
+          <Button label="登録する" size="small" type="neutral" />
         </div>
       </div>
     </header>

--- a/frontend/src/components/Header/header.module.css
+++ b/frontend/src/components/Header/header.module.css
@@ -42,8 +42,13 @@
 
   & .o_header__right_contents {
     display: flex;
-    gap: 16px;
+    gap: 12px;
     align-items: center;
+
+    & .o_header__navigation_icon_wrapper {
+      position: relative;
+      margin-right: 16px;
+    }
   }
 
   .o_header_icon_wrapper {
@@ -72,8 +77,8 @@
   & .o_header__navigation_icon_wrapper {
     & span {
       position: absolute;
-      top: 5px;
-      right: 35px;
+      top: -10px;
+      right: -20px;
 
       @media (max-width: 767px) {
         right: 15px;

--- a/frontend/src/components/SignIn/SignIn.tsx
+++ b/frontend/src/components/SignIn/SignIn.tsx
@@ -1,0 +1,7 @@
+import { FC } from 'react';
+
+const SignIn: FC = () => {
+  return <>signin</>;
+};
+
+export default SignIn;

--- a/frontend/src/components/SignUp/SignUp.tsx
+++ b/frontend/src/components/SignUp/SignUp.tsx
@@ -1,0 +1,7 @@
+import { FC } from 'react';
+
+const SignUp: FC = () => {
+  return <>signUp</>;
+};
+
+export default SignUp;


### PR DESCRIPTION
## 概要
ログインとサインアップ用のボタン、ルーティング定義 を実施した。

## Design
![image](https://github.com/user-attachments/assets/3198bbed-cc4b-4bbf-a0aa-75ca76db504b)
